### PR TITLE
fixed a typo "4" at "Proposal template: 2"

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The GSoC program is an opportunity for you to learn, explore, experiment, and bu
 Please create your GSoC proposal according to the following outline:
 
 1. Contact details (Name, Country, Email, GitHub username, Discord username, and a small description about yourself)
-2. Neutralinojs experience (Explain your familiarity with Neutralinojs)4
+2. Neutralinojs experience (Explain your familiarity with Neutralinojs)
 3. Contributions (Add links to your pull requests (include all, even if they aren't merged/reviewed yet), issues, and discussion threads)
 4.  Project description (Describe the project idea)
 5.  Goals (Summary of deliverables)


### PR DESCRIPTION
While reading the Proposal template Point number 2, I noticed there an  extra "4"-  a typo.
This PR removes the extra character.

